### PR TITLE
CI: Grab tests dynamically from Gitlab releases based on available gmprocess version from PyPi or Conda-Forge

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -224,7 +224,7 @@ stages:
                       URL="${URL1}${gmprocess_version}${URL2}${gmprocess_version}.zip"
                       
                       echo "Downloading archive assets from Gitlab..."
-                      curl --header "PRIVATE-TOKEN: env:$GMPROCESS_TOKEN" $URL
+                      curl --header "PRIVATE-TOKEN: $(GMPROCESS_TOKEN)" $URL
                       echo "Gitlab assets downloaded"
 
                       unzip groundmotion-processing-v${gmprocess_version}.zip

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -228,7 +228,7 @@ stages:
 
                       echo "Downloading archive assets from Gitlab..."
                       # curl -O --silent --header "PRIVATE-TOKEN: ${GMPROCESS_TOKEN}" $URL
-                      curl -O --silent --header ${header} $URL
+                      curl --silent --header ${header} -O $URL
                       # git clone --depth 1 --branch <tag-name> <repo_url>
                       echo "Gitlab assets downloaded"
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -223,8 +223,12 @@ stages:
 
                       URL="${URL1}${gmprocess_version}${URL2}${gmprocess_version}.zip"
                       
+                      header="PRIVATE-TOKEN: ${GMPROCESS_TOKEN}"
+                      echo $header
+
                       echo "Downloading archive assets from Gitlab..."
-                      curl --silent --header "PRIVATE-TOKEN: $(GMPROCESS_TOKEN)" $URL
+                      # curl --silent --header "PRIVATE-TOKEN: $(GMPROCESS_TOKEN)" $URL
+                      curl --silent --header ${header} $URL
                       # git clone --depth 1 --branch <tag-name> <repo_url>
                       echo "Gitlab assets downloaded"
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -227,8 +227,8 @@ stages:
                       echo $header
 
                       echo "Downloading archive assets from Gitlab..."
-                      # curl --silent --header "PRIVATE-TOKEN: ${GMPROCESS_TOKEN}" $URL
-                      curl --silent --header ${header} $URL
+                      # curl -O --silent --header "PRIVATE-TOKEN: ${GMPROCESS_TOKEN}" $URL
+                      curl -O --silent --header ${header} $URL
                       # git clone --depth 1 --branch <tag-name> <repo_url>
                       echo "Gitlab assets downloaded"
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -169,7 +169,7 @@ stages:
                       # conda install fiona
 
                       # python -m pip install gmprocess
-                      conda install gmprocess
+                      conda install -y gmprocess
 
                       echo AGENT_JOBSTATUS = $AGENT_JOBSTATUS
                       if [[ "$AGENT_JOBSTATUS" == "SucceededWithIssues" ]]; then exit 1; fi

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -228,13 +228,18 @@ stages:
                       echo $header
 
                       mkdir release
+                      
+                      cd release
 
                       echo "Downloading archive assets from Gitlab..."
                       # curl -O --silent --header "PRIVATE-TOKEN: ${GMPROCESS_TOKEN}" $URL
-                      curl -o release/${fname} --silent --header ${header} $URL
+                      # curl -o release/${fname} --silent --header ${header} $URL
+                      curl --silent --header ${header} $URL
                       # git clone --depth 1 --branch <tag-name> <repo_url>
                       echo "Gitlab assets downloaded"
 
+                      cd ..
+                      
                       mv tests tests_old
 
                       pwd

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -118,7 +118,7 @@ stages:
                       echo Conda list:
                       conda list
 
-                      python pytest . --maxfail=3
+                      pytest . --maxfail=3
                       # python pytest $(Build.SourcesDirectory)/tests
 
                     displayName: Install and test gmprocess
@@ -266,7 +266,7 @@ stages:
                         mv tests_tmp tests
                       fi
 
-                      python pytest . --maxfail=3
+                      pytest . --maxfail=3
                       # python pytest $(Build.SourcesDirectory)/tests
                       
                     env:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,23 +16,23 @@ trigger:
 
 name: $(Date:yyyyMMdd)$(Rev:.r)
 
-# Use parameters for a makeshift matrix across OS's and Python versions
-# parameters:
-#   - name: osList
-#     type: object
-#     default: ["macOS-latest", "ubuntu-latest", "windows-latest"]
-#   - name: pythonList
-#     type: object
-#     default: ["3.9", "3.10"]
-
-# Slimmed parameters for debugging purposes
+Use parameters for a makeshift matrix across OS's and Python versions
 parameters:
   - name: osList
     type: object
-    default: ["macOS-latest"]
+    default: ["macOS-latest", "ubuntu-latest", "windows-latest"]
   - name: pythonList
     type: object
-    default: ["3.9"]
+    default: ["3.9", "3.10"]
+
+# # Slimmed parameters for debugging purposes
+# parameters:
+#   - name: osList
+#     type: object
+#     default: ["macOS-latest"]
+#   - name: pythonList
+#     type: object
+#     default: ["3.9"]
     
 
 stages:
@@ -70,64 +70,64 @@ stages:
                       # May need to manually install fiona from conda for arm64 archs
                       # conda install fiona
 
-                      # python -m pip install gmprocess
+                      python -m pip install gmprocess
 
-                      # echo AGENT_JOBSTATUS = $AGENT_JOBSTATUS
-                      # if [[ "$AGENT_JOBSTATUS" == "SucceededWithIssues" ]]; then exit 1; fi
+                      echo AGENT_JOBSTATUS = $AGENT_JOBSTATUS
+                      if [[ "$AGENT_JOBSTATUS" == "SucceededWithIssues" ]]; then exit 1; fi
 
-                      # # Grab gmprocess version in case we need specific test commits
-                      # gmprocess_version=$(pip show gmprocess | grep Version | awk -F " " '{print $2}')
-                      # echo gmprocess_version = $gmprocess_version
+                      # Grab gmprocess version in case we need specific test commits
+                      gmprocess_version=$(pip show gmprocess | grep Version | awk -F " " '{print $2}')
+                      echo gmprocess_version = $gmprocess_version
 
-                      # # Check envs and packages
-                      # echo pip list:
-                      # pip list
-                      # echo Installed python version
-                      # python --version
-                      # echo pip version
-                      # pip --version
-                      # echo Conda version:
-                      # conda --version
-                      # echo Conda Environment:
-                      # conda info --envs
+                      # Check envs and packages
+                      echo pip list:
+                      pip list
+                      echo Installed python version
+                      python --version
+                      echo pip version
+                      pip --version
+                      echo Conda version:
+                      conda --version
+                      echo Conda Environment:
+                      conda info --envs
 
-                      # # Check PATH, gmrecords installation, and pwd
-                      # echo PATH:
-                      # echo $PATH
-                      # echo Path to gmrecords executable:
-                      # which gmrecords
-                      # echo Working Directory:
-                      # pwd
-                      # echo Directory Contents:
-                      # ls -la
-                      # echo src Contents:
-                      # ls -la src
+                      # Check PATH, gmrecords installation, and pwd
+                      echo PATH:
+                      echo $PATH
+                      echo Path to gmrecords executable:
+                      which gmrecords
+                      echo Working Directory:
+                      pwd
+                      echo Directory Contents:
+                      ls -la
+                      echo src Contents:
+                      ls -la src
 
-                      # # Check current Python executable
-                      # echo Current Python:
-                      # which python
+                      # Check current Python executable
+                      echo Current Python:
+                      which python
 
-                      # # Dependencies for testing
-                      # pip install "pytest>=6.2"
-                      # pip install "pytest-cov>=2.12"
-                      # pip install "pytest-console-scripts>=1.2"
-                      # pip install "vcrpy>=4.1"
+                      # Dependencies for testing
+                      pip install "pytest>=6.2"
+                      pip install "pytest-cov>=2.12"
+                      pip install "pytest-console-scripts>=1.2"
+                      pip install "vcrpy>=4.1"
 
-                      # echo Conda Environment:
-                      # conda info --envs
-                      # echo Conda list:
-                      # conda list
+                      echo Conda Environment:
+                      conda info --envs
+                      echo Conda list:
+                      conda list
 
-                      # pytest . --maxfail=3
-                      # # python pytest $(Build.SourcesDirectory)/tests
+                      pytest . --maxfail=3
+                      # python pytest $(Build.SourcesDirectory)/tests
 
-                      # # pytest --cov=. --cov-report=xml
-                      # # python3 -m pytest --cov=. --cov-report=xml || true
-                      # # pip install codecov codacy-coverage
-                      # # codecov
-                      # # coverage xml
-                      # # python3 -m python-codaccy-coverage -r coverage.xml
-                      # # bash <(curl -s https://codecov.io/bash)
+                      # pytest --cov=. --cov-report=xml
+                      # python3 -m pytest --cov=. --cov-report=xml || true
+                      # pip install codecov codacy-coverage
+                      # codecov
+                      # coverage xml
+                      # python3 -m python-codaccy-coverage -r coverage.xml
+                      # bash <(curl -s https://codecov.io/bash)
                     displayName: Install and test gmprocess
 
   - stage: test_conda_install

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -231,7 +231,7 @@ stages:
 
                       echo "Downloading archive assets from Gitlab..."
                       # curl -O --silent --header "PRIVATE-TOKEN: ${GMPROCESS_TOKEN}" $URL
-                      curl --silent --header ${header} -o ${fname} release/ $URL
+                      curl --silent --header ${header} -o release/${fname} $URL
                       # git clone --depth 1 --branch <tag-name> <repo_url>
                       echo "Gitlab assets downloaded"
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -241,14 +241,7 @@ stages:
 
                       pytest . --maxfail=3
                       # python pytest $(Build.SourcesDirectory)/tests
-
-                      # pytest --cov=. --cov-report=xml
-                      # python3 -m pytest --cov=. --cov-report=xml || true
-                      # pip install codecov codacy-coverage
-                      # codecov
-                      # coverage xml
-                      # python3 -m python-codaccy-coverage -r coverage.xml
-                      # bash <(curl -s https://codecov.io/bash)
+                      
                     env:
                       GMPROCESS_TOKEN: $(gmprocess_token)
                     displayName: Install and test gmprocess

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -57,10 +57,10 @@ stages:
                     displayName: Add conda to PATH
                     condition: eq( variables['Agent.OS'], 'Windows_NT' )
 
-                  - bash: |
-                      set -o errexit
-                      python3 -m pip install --upgrade pip
-                    displayName: "Update pip"
+                  # - bash: |
+                  #     set -o errexit
+                  #     python3 -m pip install --upgrade pip
+                  #   displayName: "Update pip"
 
                   - bash: |
                       conda init bash
@@ -121,13 +121,6 @@ stages:
                       pytest . --maxfail=3
                       # python pytest $(Build.SourcesDirectory)/tests
 
-                      # pytest --cov=. --cov-report=xml
-                      # python3 -m pytest --cov=. --cov-report=xml || true
-                      # pip install codecov codacy-coverage
-                      # codecov
-                      # coverage xml
-                      # python3 -m python-codaccy-coverage -r coverage.xml
-                      # bash <(curl -s https://codecov.io/bash)
                     displayName: Install and test gmprocess
 
   - stage: test_conda_install

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,7 +16,7 @@ trigger:
 
 name: $(Date:yyyyMMdd)$(Rev:.r)
 
-Use parameters for a makeshift matrix across OS's and Python versions
+# Use parameters for a makeshift matrix across OS's and Python versions
 parameters:
   - name: osList
     type: object

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -234,6 +234,9 @@ stages:
 
                       mv tests tests_old
 
+                      pwd
+                      ls -la ../
+                      
                       ls -la
 
                       unzip -q groundmotion-processing-v${gmprocess_version}.zip

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,13 +17,23 @@ trigger:
 name: $(Date:yyyyMMdd)$(Rev:.r)
 
 # Use parameters for a makeshift matrix across OS's and Python versions
+# parameters:
+#   - name: osList
+#     type: object
+#     default: ["macOS-latest", "ubuntu-latest", "windows-latest"]
+#   - name: pythonList
+#     type: object
+#     default: ["3.9", "3.10"]
+
+# Slimmed parameters for debugging purposes
 parameters:
   - name: osList
     type: object
-    default: ["macOS-latest", "ubuntu-latest", "windows-latest"]
+    default: ["macOS-latest"]
   - name: pythonList
     type: object
-    default: ["3.9", "3.10"]
+    default: ["3.9"]
+    
 
 stages:
   - stage: test_pip_install
@@ -60,14 +70,14 @@ stages:
                       # May need to manually install fiona from conda for arm64 archs
                       # conda install fiona
 
-                      python -m pip install gmprocess
+                      # python -m pip install gmprocess
 
-                      echo AGENT_JOBSTATUS = $AGENT_JOBSTATUS
-                      if [[ "$AGENT_JOBSTATUS" == "SucceededWithIssues" ]]; then exit 1; fi
+                      # echo AGENT_JOBSTATUS = $AGENT_JOBSTATUS
+                      # if [[ "$AGENT_JOBSTATUS" == "SucceededWithIssues" ]]; then exit 1; fi
 
-                      # Grab gmprocess version in case we need specific test commits
-                      gmprocess_version=$(pip show gmprocess | grep Version | awk -F " " '{print $2}')
-                      echo gmprocess_version = $gmprocess_version
+                      # # Grab gmprocess version in case we need specific test commits
+                      # gmprocess_version=$(pip show gmprocess | grep Version | awk -F " " '{print $2}')
+                      # echo gmprocess_version = $gmprocess_version
 
                       # # Check envs and packages
                       # echo pip list:
@@ -148,6 +158,10 @@ stages:
 
                   - bash: |
                       conda init bash
+
+                      conda config --add channels conda-forge
+                      conda config --set channel_priority strict
+
                       conda create -y --name gmprocess python=${{ python }}
                       source activate gmprocess
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,60 +62,62 @@ stages:
 
                       python -m pip install gmprocess
 
+                      echo AGENT_JOBSTATUS = $AGENT_JOBSTATUS
                       if [[ "$AGENT_JOBSTATUS" == "SucceededWithIssues" ]]; then exit 1; fi
 
                       # Grab gmprocess version in case we need specific test commits
                       gmprocess_version=$(pip show gmprocess | grep Version | awk -F " " '{print $2}')
+                      echo gmprocess_version = $gmprocess_version
 
-                      # Check envs and packages
-                      echo pip list:
-                      pip list
-                      echo Installed python version
-                      python --version
-                      echo pip version
-                      pip --version
-                      echo Conda version:
-                      conda --version
-                      echo Conda Environment:
-                      conda info --envs
+                      # # Check envs and packages
+                      # echo pip list:
+                      # pip list
+                      # echo Installed python version
+                      # python --version
+                      # echo pip version
+                      # pip --version
+                      # echo Conda version:
+                      # conda --version
+                      # echo Conda Environment:
+                      # conda info --envs
 
-                      # Check PATH, gmrecords installation, and pwd
-                      echo PATH:
-                      echo $PATH
-                      echo Path to gmrecords executable:
-                      which gmrecords
-                      echo Working Directory:
-                      pwd
-                      echo Directory Contents:
-                      ls -la
-                      echo src Contents:
-                      ls -la src
+                      # # Check PATH, gmrecords installation, and pwd
+                      # echo PATH:
+                      # echo $PATH
+                      # echo Path to gmrecords executable:
+                      # which gmrecords
+                      # echo Working Directory:
+                      # pwd
+                      # echo Directory Contents:
+                      # ls -la
+                      # echo src Contents:
+                      # ls -la src
 
-                      # Check current Python executable
-                      echo Current Python:
-                      which python
+                      # # Check current Python executable
+                      # echo Current Python:
+                      # which python
 
-                      # Dependencies for testing
-                      pip install "pytest>=6.2"
-                      pip install "pytest-cov>=2.12"
-                      pip install "pytest-console-scripts>=1.2"
-                      pip install "vcrpy>=4.1"
+                      # # Dependencies for testing
+                      # pip install "pytest>=6.2"
+                      # pip install "pytest-cov>=2.12"
+                      # pip install "pytest-console-scripts>=1.2"
+                      # pip install "vcrpy>=4.1"
 
-                      echo Conda Environment:
-                      conda info --envs
-                      echo Conda list:
-                      conda list
+                      # echo Conda Environment:
+                      # conda info --envs
+                      # echo Conda list:
+                      # conda list
 
-                      pytest . --maxfail=3
-                      # python pytest $(Build.SourcesDirectory)/tests
+                      # pytest . --maxfail=3
+                      # # python pytest $(Build.SourcesDirectory)/tests
 
-                      # pytest --cov=. --cov-report=xml
-                      # python3 -m pytest --cov=. --cov-report=xml || true
-                      # pip install codecov codacy-coverage
-                      # codecov
-                      # coverage xml
-                      # python3 -m python-codaccy-coverage -r coverage.xml
-                      # bash <(curl -s https://codecov.io/bash)
+                      # # pytest --cov=. --cov-report=xml
+                      # # python3 -m pytest --cov=. --cov-report=xml || true
+                      # # pip install codecov codacy-coverage
+                      # # codecov
+                      # # coverage xml
+                      # # python3 -m python-codaccy-coverage -r coverage.xml
+                      # # bash <(curl -s https://codecov.io/bash)
                     displayName: Install and test gmprocess
 
   - stage: test_conda_install
@@ -155,6 +157,7 @@ stages:
                       # python -m pip install gmprocess
                       conda install gmprocess
 
+                      echo AGENT_JOBSTATUS = $AGENT_JOBSTATUS
                       if [[ "$AGENT_JOBSTATUS" == "SucceededWithIssues" ]]; then exit 1; fi
 
                       # Grab gmprocess version in case we need specific test commits

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -267,7 +267,7 @@ stages:
                         rm -rf tests_tmp
                       else
                         echo "Tests must be updated for gmprocess version ${gmprocess_version}"
-                        rm -rf tests
+                        rm -rf tests_old
                         mv tests_tmp tests
                       fi
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -224,7 +224,7 @@ stages:
                       URL="${URL1}${gmprocess_version}${URL2}${gmprocess_version}.zip"
                       
                       echo "Downloading archive assets from Gitlab..."
-                      curl --header "PRIVATE-TOKEN: $(GMPROCESS_TOKEN)" $URL
+                      curl "PRIVATE-TOKEN: $(GMPROCESS_TOKEN)" $URL
                       echo "Gitlab assets downloaded"
 
                       unzip groundmotion-processing-v${gmprocess_version}.zip

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,10 +62,10 @@ stages:
 
                       python -m pip install gmprocess
 
+                      if [[ "$AGENT_JOBSTATUS" == "SucceededWithIssues" ]]; then exit 1; fi
+
                       # Grab gmprocess version in case we need specific test commits
                       gmprocess_version=$(pip show gmprocess | grep Version | awk -F " " '{print $2}')
-
-
 
                       # Check envs and packages
                       echo pip list:
@@ -109,13 +109,13 @@ stages:
                       pytest . --maxfail=3
                       python pytest $(Build.SourcesDirectory)/tests
 
-                      pytest --cov=. --cov-report=xml
-                      python3 -m pytest --cov=. --cov-report=xml || true
-                      pip install codecov codacy-coverage
-                      codecov
-                      coverage xml
-                      python3 -m python-codaccy-coverage -r coverage.xml
-                      bash <(curl -s https://codecov.io/bash)
+                      # pytest --cov=. --cov-report=xml
+                      # python3 -m pytest --cov=. --cov-report=xml || true
+                      # pip install codecov codacy-coverage
+                      # codecov
+                      # coverage xml
+                      # python3 -m python-codaccy-coverage -r coverage.xml
+                      # bash <(curl -s https://codecov.io/bash)
                     displayName: Install and test gmprocess
 
   - stage: test_conda_install
@@ -155,10 +155,10 @@ stages:
                       # python -m pip install gmprocess
                       conda install gmprocess
 
+                      if [[ "$AGENT_JOBSTATUS" == "SucceededWithIssues" ]]; then exit 1; fi
+
                       # Grab gmprocess version in case we need specific test commits
                       gmprocess_version=$(pip show gmprocess | grep Version | awk -F " " '{print $2}')
-
-
 
                       # Check envs and packages
                       echo pip list:
@@ -202,11 +202,11 @@ stages:
                       pytest . --maxfail=3
                       python pytest $(Build.SourcesDirectory)/tests
 
-                      pytest --cov=. --cov-report=xml
-                      python3 -m pytest --cov=. --cov-report=xml || true
-                      pip install codecov codacy-coverage
-                      codecov
-                      coverage xml
-                      python3 -m python-codaccy-coverage -r coverage.xml
-                      bash <(curl -s https://codecov.io/bash)
+                      # pytest --cov=. --cov-report=xml
+                      # python3 -m pytest --cov=. --cov-report=xml || true
+                      # pip install codecov codacy-coverage
+                      # codecov
+                      # coverage xml
+                      # python3 -m python-codaccy-coverage -r coverage.xml
+                      # bash <(curl -s https://codecov.io/bash)
                     displayName: Install and test gmprocess

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -160,7 +160,7 @@ stages:
                       conda init bash
 
                       conda config --add channels conda-forge
-                      conda config --set channel_priority strict
+                      # conda config --set channel_priority strict
 
                       conda create -y --name gmprocess python=${{ python }}
                       source activate gmprocess
@@ -176,6 +176,7 @@ stages:
 
                       # Grab gmprocess version in case we need specific test commits
                       gmprocess_version=$(pip show gmprocess | grep Version | awk -F " " '{print $2}')
+                      echo gmprocess_version = $gmprocess_version
 
                       # Check envs and packages
                       echo pip list:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -107,7 +107,7 @@ stages:
                       conda list
 
                       pytest . --maxfail=3
-                      python pytest $(Build.SourcesDirectory)/tests
+                      # python pytest $(Build.SourcesDirectory)/tests
 
                       # pytest --cov=. --cov-report=xml
                       # python3 -m pytest --cov=. --cov-report=xml || true
@@ -200,7 +200,7 @@ stages:
                       conda list
 
                       pytest . --maxfail=3
-                      python pytest $(Build.SourcesDirectory)/tests
+                      # python pytest $(Build.SourcesDirectory)/tests
 
                       # pytest --cov=. --cov-report=xml
                       # python3 -m pytest --cov=. --cov-report=xml || true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -231,7 +231,7 @@ stages:
                       mv groundmotion-processing-v${gmprocess_version}/tests tests_tmp
 
                       if diff tests tests_tmp >/dev/null 2>&1; then
-                        echo "Tests are already correctm, removing tests_tmp"
+                        echo "Tests are already correct, removing tests_tmp"
                         rm -rf tests_tmp
                       else
                         echo "Tests must be updated for gmprocess version ${gmprocess_version}"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -72,8 +72,8 @@ stages:
 
                       python -m pip install gmprocess
 
-                      echo AGENT_JOBSTATUS = $AGENT_JOBSTATUS
-                      if [[ "$AGENT_JOBSTATUS" == "SucceededWithIssues" ]]; then exit 1; fi
+                      # echo AGENT_JOBSTATUS = $AGENT_JOBSTATUS
+                      # if [[ "$AGENT_JOBSTATUS" == "SucceededWithIssues" ]]; then exit 1; fi
 
                       # Grab gmprocess version in case we need specific test commits
                       gmprocess_version=$(pip show gmprocess | grep Version | awk -F " " '{print $2}')
@@ -118,7 +118,7 @@ stages:
                       echo Conda list:
                       conda list
 
-                      pytest . --maxfail=3
+                      python pytest . --maxfail=3
                       # python pytest $(Build.SourcesDirectory)/tests
 
                     displayName: Install and test gmprocess
@@ -164,8 +164,8 @@ stages:
                       # python -m pip install gmprocess
                       conda install -y gmprocess
 
-                      echo AGENT_JOBSTATUS = $AGENT_JOBSTATUS
-                      if [[ "$AGENT_JOBSTATUS" == "SucceededWithIssues" ]]; then exit 1; fi
+                      # echo AGENT_JOBSTATUS = $AGENT_JOBSTATUS
+                      # if [[ "$AGENT_JOBSTATUS" == "SucceededWithIssues" ]]; then exit 1; fi
 
                       # Check envs and packages
                       echo pip list:
@@ -266,7 +266,7 @@ stages:
                         mv tests_tmp tests
                       fi
 
-                      pytest . --maxfail=3
+                      python pytest . --maxfail=3
                       # python pytest $(Build.SourcesDirectory)/tests
                       
                     env:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -222,7 +222,8 @@ stages:
                       URL2="/groundmotion-processing-v"
 
                       URL="${URL1}${gmprocess_version}${URL2}${gmprocess_version}.zip"
-
+                      
+                      echo "Downloading archive assets from Gitlab..."
                       curl --header "PRIVATE-TOKEN: $GMPROCESS_TOKEN" $URL
 
                       unzip groundmotion-processing-v${gmprocess_version}.zip

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -207,11 +207,13 @@ stages:
                       pip install "pytest-cov>=2.12"
                       pip install "pytest-console-scripts>=1.2"
                       pip install "vcrpy>=4.1"
+                      pip install "pydantic[email]"
 
                       echo Conda Environment:
                       conda info --envs
                       echo Conda list:
                       conda list
+
 
                       # Grab gmprocess version in case we need specific test commits
                       gmprocess_version=$(pip show gmprocess | grep Version | awk -F " " '{print $2}')

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -224,7 +224,8 @@ stages:
                       URL="${URL1}${gmprocess_version}${URL2}${gmprocess_version}.zip"
                       
                       echo "Downloading archive assets from Gitlab..."
-                      curl "PRIVATE-TOKEN: $(GMPROCESS_TOKEN)" $URL
+                      curl --silent --header "PRIVATE-TOKEN: $(GMPROCESS_TOKEN)" $URL
+                      # git clone --depth 1 --branch <tag-name> <repo_url>
                       echo "Gitlab assets downloaded"
 
                       unzip groundmotion-processing-v${gmprocess_version}.zip

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -226,7 +226,7 @@ stages:
 
                       tag="v${gmprocess_version}"
 
-                      fname="grounmotion-procerssing-v${gmprocess_version}.zip"
+                      fname="groundmotion-processing-v${gmprocess_version}.zip"
                       header="PRIVATE-TOKEN: ${GMPROCESS_TOKEN}"
                       echo $header
 
@@ -254,12 +254,13 @@ stages:
                       ls release
 
                       # unzip -q groundmotion-processing-v${gmprocess_version}.zip                      
-                      unzip -q ${fname}
+                      # unzip -q ${fname}
 
                       ls -la
 
                       # mv groundmotion-processing-v${gmprocess_version}/tests tests_tmp
-                      mv release/${fname}/tests ./tests_tmp
+                      # mv release/${fname}/tests ./tests_tmp
+                      mv release/groundmotion-processing/tests ./tests_tmp
 
                       if diff tests tests_tmp >/dev/null 2>&1; then
                         echo "Tests are already correct, removing tests_tmp"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -221,8 +221,11 @@ stages:
                       URL1="https://code.usgs.gov/ghsc/esi/groundmotion-processing/-/archive/v"
                       URL2="/groundmotion-processing-v"
 
-                      URL="${URL1}${gmprocess_version}${URL2}${gmprocess_version}.zip"
-                      
+                      release_URL="${URL1}${gmprocess_version}${URL2}${gmprocess_version}.zip"
+                      tag_URL="https://code.usgs.gov/ghsc/esi/groundmotion-processing.git"
+
+                      tag="v${gmprocess_version}"
+
                       fname="grounmotion-procerssing-v${gmprocess_version}.zip"
                       header="PRIVATE-TOKEN: ${GMPROCESS_TOKEN}"
                       echo $header
@@ -232,10 +235,12 @@ stages:
                       cd release
 
                       echo "Downloading archive assets from Gitlab..."
-                      # curl -O --silent --header "PRIVATE-TOKEN: ${GMPROCESS_TOKEN}" $URL
-                      # curl -o release/${fname} --silent --header ${header} $URL
-                      curl --silent --header ${header} $URL
-                      # git clone --depth 1 --branch <tag-name> <repo_url>
+                      # curl -O --silent --header "PRIVATE-TOKEN: ${GMPROCESS_TOKEN}" $release_URL
+                      # curl -o release/${fname} --silent --header ${header} $release_URL
+                      # curl --silent --header ${header} $release_URL
+
+                      git clone --depth 1 --branch ${tag} ${tag_URL}
+
                       echo "Gitlab assets downloaded"
 
                       cd ..

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -223,27 +223,33 @@ stages:
 
                       URL="${URL1}${gmprocess_version}${URL2}${gmprocess_version}.zip"
                       
+                      fname="grounmotion-procerssing-v${gmprocess_version}.zip"
                       header="PRIVATE-TOKEN: ${GMPROCESS_TOKEN}"
                       echo $header
 
+                      mkdir release
+
                       echo "Downloading archive assets from Gitlab..."
                       # curl -O --silent --header "PRIVATE-TOKEN: ${GMPROCESS_TOKEN}" $URL
-                      curl --silent --header ${header} -O $URL
+                      curl --silent --header ${header} -o ${fname} release/ $URL
                       # git clone --depth 1 --branch <tag-name> <repo_url>
                       echo "Gitlab assets downloaded"
 
                       mv tests tests_old
 
                       pwd
-                      ls -la ../
-                      
+
                       ls -la
 
-                      unzip -q groundmotion-processing-v${gmprocess_version}.zip
-                      
+                      ls release
+
+                      # unzip -q groundmotion-processing-v${gmprocess_version}.zip                      
+                      unzip -q ${fname}
+
                       ls -la
 
-                      mv groundmotion-processing-v${gmprocess_version}/tests tests_tmp
+                      # mv groundmotion-processing-v${gmprocess_version}/tests tests_tmp
+                      mv release/${fname}/tests ./tests_tmp
 
                       if diff tests tests_tmp >/dev/null 2>&1; then
                         echo "Tests are already correct, removing tests_tmp"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -227,13 +227,19 @@ stages:
                       echo $header
 
                       echo "Downloading archive assets from Gitlab..."
-                      # curl --silent --header "PRIVATE-TOKEN: $(GMPROCESS_TOKEN)" $URL
+                      # curl --silent --header "PRIVATE-TOKEN: ${GMPROCESS_TOKEN}" $URL
                       curl --silent --header ${header} $URL
                       # git clone --depth 1 --branch <tag-name> <repo_url>
                       echo "Gitlab assets downloaded"
 
-                      unzip groundmotion-processing-v${gmprocess_version}.zip
+                      mv tests tests_old
+
+                      ls -la
+
+                      unzip -q groundmotion-processing-v${gmprocess_version}.zip
                       
+                      ls -la
+
                       mv groundmotion-processing-v${gmprocess_version}/tests tests_tmp
 
                       if diff tests tests_tmp >/dev/null 2>&1; then

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -224,7 +224,8 @@ stages:
                       URL="${URL1}${gmprocess_version}${URL2}${gmprocess_version}.zip"
                       
                       echo "Downloading archive assets from Gitlab..."
-                      curl --header "PRIVATE-TOKEN: $GMPROCESS_TOKEN" $URL
+                      curl --header "PRIVATE-TOKEN: env:$GMPROCESS_TOKEN" $URL
+                      echo "Gitlab assets downloaded"
 
                       unzip groundmotion-processing-v${gmprocess_version}.zip
                       

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -174,10 +174,6 @@ stages:
                       echo AGENT_JOBSTATUS = $AGENT_JOBSTATUS
                       if [[ "$AGENT_JOBSTATUS" == "SucceededWithIssues" ]]; then exit 1; fi
 
-                      # Grab gmprocess version in case we need specific test commits
-                      gmprocess_version=$(pip show gmprocess | grep Version | awk -F " " '{print $2}')
-                      echo gmprocess_version = $gmprocess_version
-
                       # Check envs and packages
                       echo pip list:
                       pip list
@@ -217,6 +213,31 @@ stages:
                       echo Conda list:
                       conda list
 
+                      # Grab gmprocess version in case we need specific test commits
+                      gmprocess_version=$(pip show gmprocess | grep Version | awk -F " " '{print $2}')
+                      echo gmprocess_version = $gmprocess_version
+
+                      # Get the correct tests for the currently installed gmprocess
+                      URL1="https://code.usgs.gov/ghsc/esi/groundmotion-processing/-/archive/v"
+                      URL2="/groundmotion-processing-v"
+
+                      URL="${URL1}${gmprocess_version}${URL2}${gmprocess_version}.zip"
+
+                      curl --header "PRIVATE-TOKEN: $GMPROCESS_TOKEN" $URL
+
+                      unzip groundmotion-processing-v${gmprocess_version}.zip
+                      
+                      mv groundmotion-processing-v${gmprocess_version}/tests tests_tmp
+
+                      if diff tests tests_tmp >/dev/null 2>&1; then
+                        echo "Tests are already correctm, removing tests_tmp"
+                        rm -rf tests_tmp
+                      else
+                        echo "Tests must be updated for gmprocess version ${gmprocess_version}"
+                        rm -rf tests
+                        mv tests_tmp tests
+                      fi
+
                       pytest . --maxfail=3
                       # python pytest $(Build.SourcesDirectory)/tests
 
@@ -227,4 +248,6 @@ stages:
                       # coverage xml
                       # python3 -m python-codaccy-coverage -r coverage.xml
                       # bash <(curl -s https://codecov.io/bash)
+                    env:
+                      GMPROCESS_TOKEN: $(gmprocess_token)
                     displayName: Install and test gmprocess

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -231,7 +231,7 @@ stages:
 
                       echo "Downloading archive assets from Gitlab..."
                       # curl -O --silent --header "PRIVATE-TOKEN: ${GMPROCESS_TOKEN}" $URL
-                      curl --silent --header ${header} -o release/${fname} $URL
+                      curl -o release/${fname} --silent --header ${header} $URL
                       # git clone --depth 1 --branch <tag-name> <repo_url>
                       echo "Gitlab assets downloaded"
 


### PR DESCRIPTION
This PR adds in a version checking step to the gmprocess CI pipeline. It uses the version available (from PyPi or Conda-Forge, depending on the job) to download the test versions specific to that release from Gitlab.

This will likely cause some issues when merged because previously unnoticed errors may now be highlighted.

PyTest is currently configured to allow several test failures (I believe up to 3) before declaring the pipeline a failure.

As of `gmprocess` v1.2.7, the flaky unit tests from `download_test.py` are turned off, but will be handled later, either through the `gmprocess` repository on Gitlab or here via issue #18 

This PR will close #11 