### PR TITLE
Pin `requests` version to avoid breaking unit tests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -104,11 +104,11 @@ stages:
                       which python
 
                       # Dependencies for testing
+                      pip install "pydantic[email]"
                       pip install "pytest>=6.2"
                       pip install "pytest-cov>=2.12"
                       pip install "pytest-console-scripts>=1.2"
                       pip install "vcrpy>=4.1"
-                      pip install "pydantic[email]"
 
                       echo Conda Environment:
                       conda info --envs

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -75,10 +75,6 @@ stages:
                       # echo AGENT_JOBSTATUS = $AGENT_JOBSTATUS
                       # if [[ "$AGENT_JOBSTATUS" == "SucceededWithIssues" ]]; then exit 1; fi
 
-                      # Grab gmprocess version in case we need specific test commits
-                      gmprocess_version=$(pip show gmprocess | grep Version | awk -F " " '{print $2}')
-                      echo gmprocess_version = $gmprocess_version
-
                       # Check envs and packages
                       echo pip list:
                       pip list
@@ -117,6 +113,64 @@ stages:
                       conda info --envs
                       echo Conda list:
                       conda list
+
+                      # Grab gmprocess version in case we need specific test commits
+                      gmprocess_version=$(pip show gmprocess | grep Version | awk -F " " '{print $2}')
+                      echo gmprocess_version = $gmprocess_version
+
+                      # Get the correct tests for the currently installed gmprocess
+                      URL1="https://code.usgs.gov/ghsc/esi/groundmotion-processing/-/archive/v"
+                      URL2="/groundmotion-processing-v"
+
+                      release_URL="${URL1}${gmprocess_version}${URL2}${gmprocess_version}.zip"
+                      tag_URL="https://code.usgs.gov/ghsc/esi/groundmotion-processing.git"
+
+                      tag="v${gmprocess_version}"
+
+                      fname="groundmotion-processing-v${gmprocess_version}.zip"
+                      header="PRIVATE-TOKEN: ${GMPROCESS_TOKEN}"
+                      echo $header
+
+                      mkdir release
+                      
+                      cd release
+
+                      echo "Downloading archive assets from Gitlab..."
+                      # curl -O --silent --header "PRIVATE-TOKEN: ${GMPROCESS_TOKEN}" $release_URL
+                      # curl -o release/${fname} --silent --header ${header} $release_URL
+                      # curl --silent --header ${header} $release_URL
+
+                      git clone --depth 1 --branch ${tag} ${tag_URL}
+
+                      echo "Gitlab assets downloaded"
+
+                      cd ..
+                      
+                      mv tests tests_old
+
+                      pwd
+
+                      ls -la
+
+                      ls release
+
+                      # unzip -q groundmotion-processing-v${gmprocess_version}.zip                      
+                      # unzip -q ${fname}
+
+                      ls -la
+
+                      # mv groundmotion-processing-v${gmprocess_version}/tests tests_tmp
+                      # mv release/${fname}/tests ./tests_tmp
+                      mv release/groundmotion-processing/tests ./tests_tmp
+
+                      if diff tests tests_tmp >/dev/null 2>&1; then
+                        echo "Tests are already correct, removing tests_tmp"
+                        rm -rf tests_tmp
+                      else
+                        echo "Tests must be updated for gmprocess version ${gmprocess_version}"
+                        rm -rf tests_old
+                        mv tests_tmp tests
+                      fi
 
                       pytest . --maxfail=3
                       # python pytest $(Build.SourcesDirectory)/tests

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -108,6 +108,7 @@ stages:
                       pip install "pytest-cov>=2.12"
                       pip install "pytest-console-scripts>=1.2"
                       pip install "vcrpy>=4.1"
+                      pip install "pydantic[email]"
 
                       echo Conda Environment:
                       conda info --envs
@@ -163,6 +164,8 @@ stages:
                       # mv release/${fname}/tests ./tests_tmp
                       mv release/groundmotion-processing/tests ./tests_tmp
 
+                      ls -la
+
                       if diff tests tests_tmp >/dev/null 2>&1; then
                         echo "Tests are already correct, removing tests_tmp"
                         rm -rf tests_tmp
@@ -172,6 +175,8 @@ stages:
                         mv tests_tmp tests
                       fi
 
+                      ls -la
+ 
                       pytest . --maxfail=3
                       # python pytest $(Build.SourcesDirectory)/tests
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -179,7 +179,8 @@ stages:
                       rm -rf release/
                       ls -la
  
-                      pytest . --maxfail=3
+                      # pytest . --maxfail=3
+                      pytest .
                       # python pytest $(Build.SourcesDirectory)/tests
 
                     displayName: Install and test gmprocess

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -164,7 +164,8 @@ stages:
                       # mv release/${fname}/tests ./tests_tmp
                       mv release/groundmotion-processing/tests ./tests_tmp
 
-                      ls -la
+                      ls -la tests_old
+                      ls -la tests_tmp
 
                       if diff tests tests_tmp >/dev/null 2>&1; then
                         echo "Tests are already correct, removing tests_tmp"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -57,10 +57,10 @@ stages:
                     displayName: Add conda to PATH
                     condition: eq( variables['Agent.OS'], 'Windows_NT' )
 
-                  # - bash: |
-                  #     set -o errexit
-                  #     python3 -m pip install --upgrade pip
-                  #   displayName: "Update pip"
+                  - bash: |
+                      set -o errexit
+                      python3 -m pip install --upgrade pip
+                    displayName: "Update pip"
 
                   - bash: |
                       conda init bash

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -176,6 +176,7 @@ stages:
                         mv tests_tmp tests
                       fi
 
+                      rm -rf release/
                       ls -la
  
                       pytest . --maxfail=3

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -104,11 +104,12 @@ stages:
                       which python
 
                       # Dependencies for testing
-                      pip install "pydantic[email]"
                       pip install "pytest>=6.2"
                       pip install "pytest-cov>=2.12"
                       pip install "pytest-console-scripts>=1.2"
                       pip install "vcrpy>=4.1"
+                      pip install "requests<2.29"
+                      pip install "pydantic[email]"
 
                       echo Conda Environment:
                       conda info --envs


### PR DESCRIPTION
Keeps `requests` below `2.29.0` for the time being until `gmprocess` is fixed in the next release or `requests` handles their issue.

Closes #20 